### PR TITLE
Fix incorrect assert() handling

### DIFF
--- a/debugger/lldebugger.lua
+++ b/debugger/lldebugger.lua
@@ -1843,7 +1843,7 @@ do
         local args = {...}
         if not v then
             local message = ((args[1] ~= nil) and args[1]) or "assertion failed"
-            breakForError(message, 1, true)
+            breakForError(message, 2, true)
         end
         return v, unpack(args)
     end


### PR DESCRIPTION
Fixes https://github.com/tomblind/local-lua-debugger-vscode/issues/74 by starting the trace one level deeper, skipping over `debuggerAssert` as was likely intended. This is the fix suggested by @TIMONz1535 in the issue on the original repo.