### PR TITLE
fix: f233464 applied only to compiled `lldebugger.lua`

### DIFF
--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -1135,7 +1135,7 @@ export namespace Debugger {
     function debuggerAssert(v: unknown, ...args: unknown[]) {
         if (!v) {
             const message = args[0] !== undefined && args[0] || "assertion failed";
-            breakForError(message, 1, true);
+            breakForError(message, 2, true);
         }
         return $multi(v, ...args);
     }

--- a/debugger/lldebugger.lua
+++ b/debugger/lldebugger.lua
@@ -1843,7 +1843,7 @@ do
         local args = {...}
         if not v then
             local message = ((args[1] ~= nil) and args[1]) or "assertion failed"
-            breakForError(message, 1, true)
+            breakForError(message, 2, true)
         end
         return v, unpack(args)
     end


### PR DESCRIPTION
The previous PR (commit f233464dfcee21a3de9bd9655ebdf054b3bfe0d6) did not apply the patch to the source `debugger.ts` file, so the change would be lost in subsequent releases and in fact also during publish, which is why the last version, had no real change.

This PR simply adopts the intended change for the `debugger.ts` file.

@Ismoh could you please explain the steps to me for publishing a new version? I believe this PR would make a perfect example.
 