### PR TITLE
Remove the extensionPath config

### DIFF
--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -97,12 +97,6 @@ const configurationProvider: vscode.DebugConfigurationProvider = {
             return abortLaunch("No path for debugger");
         }
 
-        const extension = vscode.extensions.getExtension("ismoh-games.second-local-lua-debugger-vscode");
-        if (typeof extension === "undefined") {
-            return abortLaunch("Failed to find extension path");
-        }
-        config.extensionPath = extension.extensionPath;
-
         if (typeof config.cwd === "undefined") {
             config.cwd = config.workspacePath;
         }

--- a/extension/launchConfig.ts
+++ b/extension/launchConfig.ts
@@ -32,7 +32,6 @@ export interface CustomProgramConfig {
 }
 
 export interface LaunchConfig {
-    extensionPath: string;
     workspacePath: string;
     program: LuaProgramConfig | CustomProgramConfig;
     args?: string[];

--- a/extension/luaDebugSession.ts
+++ b/extension/luaDebugSession.ts
@@ -234,7 +234,7 @@ export class LuaDebugSession extends LoggingDebugSession {
         //Set an environment variable so the debugger can detect the attached extension
         processOptions.env[envVariable] = "1";
         processOptions.env[filePathEnvVariable]
-            = `${this.config.extensionPath}${path.sep}debugger${path.sep}lldebugger.lua`;
+            = path.join(path.dirname(__dirname), "debugger", "lldebugger.lua");
 
         //Pass options via environment variables
         if (typeof this.config.scriptRoots !== "undefined") {
@@ -839,7 +839,7 @@ export class LuaDebugSession extends LoggingDebugSession {
             luaPath += ";";
         }
 
-        env[luaPathKey] = `${luaPath}${this.assert(this.config).extensionPath}/debugger/?.lua`;
+        env[luaPathKey] = `${luaPath}${path.dirname(__dirname)}/debugger/?.lua`;
     }
 
     private setBreakpoint(filePath: string, breakpoint: DebugProtocol.SourceBreakpoint) {


### PR DESCRIPTION
This pull request removes extensionPath from the configs.

The extensionPath config key was initially used to add the extension path to the Lua path before executing user code so that it could locate lldebugger.lua when required. The code has been updated to use __dirname to find the path, eliminating the need for this configuration key. This change simplifies the server configuration for Vim/Neovim or any other non-vscode editor while maintaining compatibility with vscode. The functionality has been tested by and confirmed to work in vscode. I have tested only in Linux, though.

Testing
Linux: Changes have been tested and verified on neovim and vscode.
Windows and macOS: Need someone to thest on these

