### PR TITLE
Fix #25: Change the error wrapper to pass the original error intact

### DIFF
--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -1042,7 +1042,7 @@ export namespace Debugger {
 
         if (propagate) {
             skipNextBreak = true;
-            luaError(message, level);
+            luaError(err, level);
         }
     }
 

--- a/debugger/lib.lua51.d.ts
+++ b/debugger/lib.lua51.d.ts
@@ -125,7 +125,7 @@ declare function dofile(this: void, filename?: string): LuaMultiReturn<unknown[]
  *   the `error` function was called. Level 2 points the error to where the function that called `error` was called; and
  *   so on. Passing a level 0 avoids the addition of error position information to the message.
 */
-declare function error(this: void, message: string, level?: number): never;
+declare function error(this: void, message: any, level?: number): never;
 
 /**
  * A global variable (not a function) that holds the global environment (that is, `_G._G = _G`). Lua itself does not use


### PR DESCRIPTION
This place in the code was intercepting errors and substituting the error value by a string version of it. After this change it worked as intended.